### PR TITLE
Updated lexer to handle escaped double quotes within string literals

### DIFF
--- a/hl2parse-parsers/src/main/antlr3/com/technofovea/hl2parse/vdf/ValveTokenLexer.g
+++ b/hl2parse-parsers/src/main/antlr3/com/technofovea/hl2parse/vdf/ValveTokenLexer.g
@@ -81,7 +81,7 @@ MINUS 	:	 '-';
 DOT 	: 	 '.';
     
 STRING
-    : QUOT (  ~QUOT )* QUOT
+    : QUOT (  ~QUOT | '\\"')* QUOT
     {
     setText(getText().substring(1, getText().length()-1));
     }

--- a/hl2parse-tests/src/test/java/com/technofovea/hl2parse/vdf/ParseTest.java
+++ b/hl2parse-tests/src/test/java/com/technofovea/hl2parse/vdf/ParseTest.java
@@ -44,6 +44,7 @@ public class ParseTest {
     static final String PARTICLE_MANIFEST = "particles_manifest.txt";
     static final String SDK_GAME_CONFIG = "GameConfig.txt";
     static final String SOUNDSCAPE = "soundscapes_2fort.txt";
+    static final String TOKEN_FILE = "dota_english.txt";
 
     private void assertSameItems(String[] expectedArray, Collection<String> actualCollection) {
         Set<String> expected = new HashSet<String>();
@@ -273,5 +274,19 @@ public class ParseTest {
         SteamMetaReader smr = new SteamMetaReader(root);
 
         Assert.assertEquals("user@example.com", smr.getAutoLogon());
+    }
+    
+    @Test
+    public void testDotaEnglishTokenFile() throws Exception {
+        File tokenFile = new File(getClass().getResource(TOKEN_FILE).toURI());
+        VdfRoot root = doSloppyParse(new FileInputStream(tokenFile));
+        
+        VdfNode langNode = root.getChildren().get(0);
+        
+        Assert.assertEquals("lang", langNode.getName());
+        
+        VdfAttribute descriptionAttribute = langNode.getChildren().get(0).getAttributes().get(0);
+
+        Assert.assertEquals("Casts a poisonous spell <font color=\\\"#ff66ff\\\">LEVEL 3</font>", descriptionAttribute.getValue());
     }
 }

--- a/hl2parse-tests/src/test/resources/com/technofovea/hl2parse/vdf/dota_english.txt
+++ b/hl2parse-tests/src/test/resources/com/technofovea/hl2parse/vdf/dota_english.txt
@@ -1,0 +1,9 @@
+"lang" 
+{ 
+	"Language" "English" 
+	"Tokens" 
+	{
+		"DOTA_Tooltip_ability_dazzle_poison_touch_Description"							"Casts a poisonous spell <font color=\"#ff66ff\">LEVEL 3</font>"
+	}
+}
+


### PR DESCRIPTION
Updated lexer to handle escaped double quotes within string literals, included unit test for the respective scenario.

This issue was encountered when parsing Dota 2 resource files.
